### PR TITLE
Add error returns for handler functions

### DIFF
--- a/crudkit-derive/src/derives/derive_functions.rs
+++ b/crudkit-derive/src/derives/derive_functions.rs
@@ -324,7 +324,7 @@ pub fn derive_write_record(input: TokenStream2) -> SynResult<TokenStream2> {
             async fn update_one(
                 database: &crudkit::database::PgDatabase,
                 update_params: Self::UpdateQueryParameters,
-            ) {
+            ) -> Result<(), crudkit::error::Error> {
                 let #update_params_type_name {
                     #(
                         #type_field_idents
@@ -355,7 +355,12 @@ pub fn derive_write_record(input: TokenStream2) -> SynResult<TokenStream2> {
                 )*
 
                 if !column_bind_specifiers.is_empty() {
-                    query.execute(&database.connection).await.unwrap();
+                    match query.execute(&database.connection).await {
+                        Ok(_) => Ok(()),
+                        Err(e) => Err(crudkit::error::Error::from(e)),
+                    }
+                } else {
+                    Err(crudkit::error::Error::InvalidQuery)
                 }
             }
         }

--- a/crudkit-derive/src/derives/derive_functions.rs
+++ b/crudkit-derive/src/derives/derive_functions.rs
@@ -360,7 +360,11 @@ pub fn derive_write_record(input: TokenStream2) -> SynResult<TokenStream2> {
                         Err(e) => Err(crudkit::error::Error::from(e)),
                     }
                 } else {
-                    Err(crudkit::error::Error::InvalidQuery)
+                    Err(crudkit::error::Error {
+                        kind: crudkit::error::ErrorKind::InvalidQuery,
+                        source: None,
+                        status_code: crudkit::http::StatusCode::NOT_FOUND,
+                    })
                 }
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,9 +3,10 @@ use sqlx::Error as SqlxError;
 
 pub(crate) type Result<T> = core::result::Result<T, Error>;
 
+// TODO: Add documentation
 pub struct Error {
     pub kind: ErrorKind,
-    pub source: SqlxError,
+    pub source: Option<SqlxError>,
     status_code: StatusCode,
 }
 
@@ -28,7 +29,7 @@ impl From<SqlxError> for Error {
             | SqlxError::WorkerCrashed
             | SqlxError::Database(_) => Self {
                 kind: ErrorKind::BrokenDatabaseConnection,
-                source: source_error,
+                source: Some(source_error),
                 status_code: StatusCode::INTERNAL_SERVER_ERROR,
             },
             SqlxError::TypeNotFound { .. }
@@ -36,17 +37,17 @@ impl From<SqlxError> for Error {
             | SqlxError::ColumnNotFound(_)
             | SqlxError::Encode(_) => Self {
                 kind: ErrorKind::InvalidQuery,
-                source: source_error,
+                source: Some(source_error),
                 status_code: StatusCode::BAD_REQUEST,
             },
             SqlxError::RowNotFound => Self {
                 kind: ErrorKind::UnexpectedQueryResult,
-                source: source_error,
+                source: Some(source_error),
                 status_code: StatusCode::NOT_FOUND,
             },
             SqlxError::Decode(_) => Self {
                 kind: ErrorKind::UnexpectedQueryResult,
-                source: source_error,
+                source: Some(source_error),
                 status_code: StatusCode::INTERNAL_SERVER_ERROR,
             },
             _ => todo!(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,43 @@
+use http::StatusCode;
+use sqlx::Error as SqlxError;
+
+pub(crate) type Result<T> = core::result::Result<T, Error>;
+
+pub enum Error {
+    BrokenDatabaseConnection,
+    InvalidQuery,
+    UnexpectedQueryResult,
+}
+
+impl From<SqlxError> for Error {
+    fn from(value: SqlxError) -> Self {
+        match value {
+            SqlxError::Configuration(_)
+            | SqlxError::Io(_)
+            | SqlxError::Tls(_)
+            | SqlxError::Protocol(_)
+            | SqlxError::AnyDriverError(_)
+            | SqlxError::PoolTimedOut
+            | SqlxError::PoolClosed
+            | SqlxError::WorkerCrashed
+            | SqlxError::Database(_) => Self::BrokenDatabaseConnection,
+            SqlxError::TypeNotFound { .. }
+            | SqlxError::ColumnIndexOutOfBounds { .. }
+            | SqlxError::ColumnNotFound(_)
+            | SqlxError::Encode(_) => Self::InvalidQuery,
+            SqlxError::RowNotFound | SqlxError::Decode(_) => Self::UnexpectedQueryResult,
+            _ => todo!(),
+        }
+    }
+}
+
+impl From<Error> for StatusCode {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::BrokenDatabaseConnection | Error::UnexpectedQueryResult => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Error::InvalidQuery => StatusCode::BAD_REQUEST,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod error;
 pub mod traits;
 
 pub use crudkit_derive::*;
+pub use http;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod database;
+pub mod error;
 pub mod traits;
 
 pub use crudkit_derive::*;

--- a/src/traits/shared.rs
+++ b/src/traits/shared.rs
@@ -1,4 +1,5 @@
 use rand::{rng, Rng};
+use serde::Serialize;
 use sqlx::postgres::PgRow;
 
 #[allow(unused_imports)]
@@ -13,7 +14,7 @@ use super::write::{WriteRecord, WriteRelation};
 /// derived, particularly [`ReadRelation`], [`WriteRelation`], [`ReadRecord`], and [`WriteRecord`].
 ///
 /// Also see [`Record`].
-pub trait Relation: Sized + Send + Sync {
+pub trait Relation: Serialize + Sized + Send + Sync {
     /// The record type which this relation contains a collection of.
     ///
     /// This type and the [`Record::Relation`] type are directly interreferential to allow
@@ -67,7 +68,9 @@ pub trait Relation: Sized + Send + Sync {
 /// derived, particularly [`ReadRelation`], [`WriteRelation`], [`ReadRecord`], and [`WriteRecord`].
 ///
 /// Also see [`Relation`].
-pub trait Record: for<'a> sqlx::FromRow<'a, PgRow> + Send + Sync + Unpin + Clone {
+pub trait Record:
+    Serialize + for<'a> sqlx::FromRow<'a, PgRow> + Send + Sync + Unpin + Clone
+{
     /// The relation type which contains a collection of this record type.
     ///
     /// This type and the [`Relation::Record`] type are directly interreferential to allow

--- a/tests/integration_test_1.rs
+++ b/tests/integration_test_1.rs
@@ -3,6 +3,8 @@
 #[path = "./database_connection.rs"]
 mod database_connection;
 
+use serde::Serialize;
+
 use crudkit::{
     traits::{
         id_parameter::{GenericIdParameter, IdParameter},
@@ -14,14 +16,21 @@ use crudkit::{
 };
 use database_connection::get_database;
 
-#[derive(Relation, ReadRelation, WriteRelation, BulkInsert, Clone)]
+#[derive(Relation, ReadRelation, WriteRelation, BulkInsert, Clone, Serialize)]
 #[relation(relation_name = "customers", primary_key = "id")]
 pub struct CustomersTable {
     records: Vec<CustomersTableRecord>,
 }
 
 #[derive(
-    Record, ReadRecord, WriteRecord, SingleInsert, IdentifiableRecord, sqlx::FromRow, Clone,
+    Record,
+    ReadRecord,
+    WriteRecord,
+    SingleInsert,
+    IdentifiableRecord,
+    sqlx::FromRow,
+    Clone,
+    Serialize,
 )]
 pub struct CustomersTableRecord {
     #[auto_primary_key]


### PR DESCRIPTION
This PR adds error mapping for SQLX error types, and uses an internal error type as an intermediary between `StatusCode` and `sqlx::Error`. The non-Axum versions of the handler functions return the internal error type (`crudkit::error::Error`, aliased as `CrudkitError`) whereas the Axum versions return an appropriate `StatusCode`.